### PR TITLE
OS X: Fix clipboard inadvertedly being cleared when using wxNotebook

### DIFF
--- a/src/cocoa/notebook.mm
+++ b/src/cocoa/notebook.mm
@@ -113,12 +113,6 @@ WX_DECLARE_GET_OBJC_CLASS(WXCTabViewImageItem,NSTabViewItem)
     m_image = image;
     if(!m_image)
         return;
-    [[NSPasteboard generalPasteboard]
-        declareTypes:[NSArray arrayWithObject:NSTIFFPboardType]
-        owner:nil];
-    [[NSPasteboard generalPasteboard]
-        setData:[m_image TIFFRepresentation]
-        forType:NSTIFFPboardType];
 }
 
 @end // implementation WXCTabViewImageItem : NSTabViewItem


### PR DESCRIPTION
Using wxNotebook::SetPageImage changes the global clipboard which it must not.
